### PR TITLE
Dockerfile refactor removes extra node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,5 @@
 .travis.yml
 Dockerfile
 LICENSE
+node_modules/
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,14 @@
 
 FROM rackhd/on-core
 
-RUN mkdir -p /RackHD/on-statsd
+COPY . /RackHD/on-statsd/
 WORKDIR /RackHD/on-statsd
 
 COPY ./package.json /tmp/
-RUN cd /tmp \
-  && ln -s /RackHD/on-core /tmp/node_modules/on-core \
-  && ln -s /RackHD/on-core/node_modules/di /tmp/node_modules/di \
+RUN mkdir -p ./node_modules \
+  && ln -s /RackHD/on-core ./node_modules/on-core \
+  && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && npm install --ignore-scripts --production
 
-COPY . /RackHD/on-statsd/
-RUN cp -a -f /tmp/node_modules /RackHD/on-statsd/
-
 EXPOSE 8125/udp
-
 CMD [ "node", "/RackHD/on-statsd/index.js" ]


### PR DESCRIPTION
Removes extra copy of node_modules directory which reduces the size of the docker image.
