### PR TITLE
Default to node 4 travis builds. Optionally build node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: node_js
 
 node_js:
-  - "0.10"
   - "4"
-  - "5"
+  - "6"
 
 matrix:
   allow_failures:
-   - node_js: "5"
+   - node_js: "6"
 
 notifications:
   slack:


### PR DESCRIPTION
Updating travis files in favor of deprecating Node 0.10 support.

Docs for ubuntu installation/upgrade https://github.com/RackHD/docs/pull/286

@RackHD/corecommitters @RackHD/rackhd_dev 